### PR TITLE
Test: Use Sinon.js instead of FakeDate

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,11 +14,13 @@
   },
   "devDependencies": {
     "es5-shim": "3.4.0",
+    "lolex": "sinonjs/lolex#3664eb",
     "make-plural": "eemeli/make-plural.js#2.1.2",
     "messageformat": "SlexAxton/messageformat.js#debeaf4",
     "qunit": "1.16.0",
     "requirejs": "2.1.9",
     "requirejs-plugins": "1.0.2",
-    "requirejs-text": "2.0.10"
+    "requirejs-text": "2.0.10",
+    "sinon": "1.12.2"
   }
 }

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,8 +1,13 @@
 require.config({
 	paths: {
-		cldr: "../external/cldrjs/dist/cldr",
 		"cldr-data": "../external/cldr-data",
+		cldr: "../external/cldrjs/dist/cldr",
 		json: "../external/requirejs-plugins/src/json",
+
+		// Sinon.js dependency.
+		lolex: "../external/lolex/lolex",
+
+		sinon: "../external/sinon/lib/sinon",
 		src: "../src",
 		text: "../external/requirejs-text/text"
 	},

--- a/test/unit/date/parse.js
+++ b/test/unit/date/parse.js
@@ -1,5 +1,6 @@
 define([
 	"cldr",
+	"sinon",
 	"src/date/parse",
 	"src/date/parse-properties",
 	"src/date/start-of",
@@ -13,7 +14,7 @@ define([
 
 	"cldr/event",
 	"cldr/supplemental"
-], function( Cldr, parse, parseProperties, startOf, tokenizer, numberTokenizerProperties,
+], function( Cldr, sinon, parse, parseProperties, startOf, tokenizer, numberTokenizerProperties,
 	enCaGregorian, enNumbers, likelySubtags, timeData, weekData ) {
 
 var cldr, date1, date2, FakeDate, midnight;
@@ -195,31 +196,26 @@ QUnit.test( "should parse month (MMMMM|LLLLL)", function( assert ) {
  */
 
 QUnit.test( "should parse day (d) with no padding", function( assert ) {
-	var OrigDate;
+	var clock;
 
 	date1 = new Date();
 	date1.setDate( 2 );
 	date1 = startOf( date1, "day" );
 	assertParse( assert, "2", "d", cldr, date1 );
 
-	/* globals Date:true */
 	// Test #323 - Day parsing must use the correct day range given its corresponding month/year.
-	OrigDate = Date;
-	Date = FakeDate;
-
+	// `sinon.useFakeTimers( date )` overwrites Date with a custom implementation, where now = date.
 	date1 = new Date( 2014, 1, 28 );
-	date1 = startOf( date1, "day" );
-	FakeDate.today = new Date( 2014, 1 );
+	clock = sinon.useFakeTimers( new Date( 2014, 1 ).getTime() );
 	assertParse( assert, "29", "d", cldr, null );
 	assertParse( assert, "28", "d", cldr, date1 );
+	clock.restore();
 
 	date2 = new Date( 2016, 1, 29 );
-	date2 = startOf( date2, "day" );
-	FakeDate.today = new Date( 2016, 1 );
+	clock = sinon.useFakeTimers( new Date( 2016, 1 ).getTime() );
 	assertParse( assert, "30", "d", cldr, null );
 	assertParse( assert, "29", "d", cldr, date2 );
-
-	Date = OrigDate;
+	clock.restore();
 });
 
 QUnit.test( "should parse day (dd) with padding", function( assert ) {
@@ -230,7 +226,7 @@ QUnit.test( "should parse day (dd) with padding", function( assert ) {
 });
 
 QUnit.test( "should parse day of year (D) with no padding", function( assert ) {
-	var OrigDate;
+	var clock;
 
 	date1 = new Date();
 	date1.setMonth( 0 );
@@ -238,20 +234,17 @@ QUnit.test( "should parse day of year (D) with no padding", function( assert ) {
 	date1 = startOf( date1, "day" );
 	assertParse( assert, "2", "D", cldr, date1 );
 
-	/* globals Date:true */
 	// Test #323 - Day of year parsing must use the correct day range given leap year into account.
-	OrigDate = Date;
-	Date = FakeDate;
-
-	FakeDate.today = new Date( 2014, 1 );
+	// `sinon.useFakeTimers( date )` overwrites Date with a custom implementation, where now = date.
+	clock = sinon.useFakeTimers( new Date( 2014, 1 ).getTime() );
 	assertParse( assert, "366", "D", cldr, null );
+	clock.restore();
 
 	// date1 = last day of 2016
 	date1 = new Date( 2017, 0, 0 );
-	FakeDate.today = new Date( 2016, 1 );
+	clock = sinon.useFakeTimers( new Date( 2016, 1 ).getTime() );
 	assertParse( assert, "366", "D", cldr, date1 );
-
-	Date = OrigDate;
+	clock.restore();
 });
 
 QUnit.test( "should parse day of year (DD|DDD) with padding", function( assert ) {


### PR DESCRIPTION
Note: lolex's 3664eb8d90dd1d6fa04a098f77b77b19a6bb5850 sha corresponds
to its 1.1.0 npm version (version is present on npm, but not git tagged
accordingly).

Ref #374
Fixes #382