### PR TITLE
Number rounding: Avoid inaccurate floating point arithmetics

### DIFF
--- a/src/util/number/round.js
+++ b/src/util/number/round.js
@@ -7,11 +7,12 @@ define([
  *
  * @method [String] with either "round", "ceil", "floor", or "truncate".
  *
- * Return function( value, increment ):
+ * Return function( value, incrementOrExp ):
  *
  *   @value [Number] eg. 123.45.
  *
- *   @increment [Number] optional, eg. 0.1.
+ *   @incrementOrExp [Number] optional, eg. 0.1; or
+ *     [Object] Either { increment: <value> } or { exponent: <value> }
  *
  *   Return the rounded number, eg:
  *   - round( "round" )( 123.45 ): 123;
@@ -20,13 +21,67 @@ define([
  *   - round( "truncate" )( 123.45 ): 123;
  *   - round( "round" )( 123.45, 0.1 ): 123.5;
  *   - round( "round" )( 123.45, 10 ): 120;
+ *
+ *   Based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
+ *   Ref: #376
  */
 return function( method ) {
 	method = method || "round";
 	method = method === "truncate" ? numberTruncate : Math[ method ];
-	return function( value, increment ) {
-		increment = increment || 1;
-		return method( value / increment ) * increment;
+
+	return function( value, incrementOrExp ) {
+		var exp, increment;
+
+		value = +value;
+
+		// If the value is not a number, return NaN.
+		if ( isNaN( value ) ) {
+			return NaN;
+		}
+
+		// Exponent given.
+		if ( typeof incrementOrExp === "object" && incrementOrExp.exponent ) {
+			exp = +incrementOrExp.exponent;
+			increment = 1;
+
+			if ( exp === 0 ) {
+				return method( value );
+			}
+
+			// If the exp is not an integer, return NaN.
+			if ( !( typeof exp === "number" && exp % 1 === 0 ) ) {
+				return NaN;
+			}
+
+		// Increment given.
+		} else {
+			increment = +incrementOrExp || 1;
+
+			if ( increment === 1 ) {
+				return method( value );
+			}
+
+			// If the increment is not a number, return NaN.
+			if ( isNaN( increment ) ) {
+				return NaN;
+			}
+
+			increment = increment.toExponential().split( "e" );
+			exp = +increment[ 1 ];
+			increment = +increment[ 0 ];
+		}
+
+		// Shift & Round
+		value = value.toString().split( "e" );
+		value[ 0 ] = +value[ 0 ] / increment;
+		value[ 1 ] = value[ 1 ] ? ( +value[ 1 ] - exp ) : -exp;
+		value = method( +(value[ 0 ] + "e" + value[ 1 ] ) );
+
+		// Shift back
+		value = value.toString().split( "e" );
+		value[ 0 ] = +value[ 0 ] * increment;
+		value[ 1 ] = value[ 1 ] ? ( +value[ 1 ] + exp ) : exp;
+		return +( value[ 0 ] + "e" + value[ 1 ] );
 	};
 };
 

--- a/src/util/number/to-precision.js
+++ b/src/util/number/to-precision.js
@@ -12,7 +12,7 @@ define(function() {
  * Return number.toPrecision( precision ) using the given round function.
  */
 return function( number, precision, round ) {
-	var roundOrder, roundIncrement;
+	var roundOrder;
 
 	// Get number at two extra significant figure precision.
 	number = number.toPrecision( precision + 2 );
@@ -20,16 +20,8 @@ return function( number, precision, round ) {
 	// Then, round it to the required significant figure precision.
 	roundOrder = Math.ceil( Math.log( Math.abs( number ) ) / Math.log( 10 ) );
 	roundOrder -= precision;
-	roundIncrement = Math.pow( 10, roundOrder );
 
-	number = round( number, roundIncrement );
-
-	// Ignore decimal error, eg. `1234 * 0.0001 = 0.12340000000000001`.
-	if ( roundOrder < 0 ) {
-		number = +number.toFixed( -roundOrder );
-	}
-
-	return number;
+	return round( number, { exponent: roundOrder } );
 };
 
 });

--- a/test/unit/number/format.js
+++ b/test/unit/number/format.js
@@ -152,8 +152,8 @@ QUnit.test( "should allow rounding", function( assert ) {
 	assert.equal( format( pi, properties( "0.5", en ) ), "3.0" );
 	assert.equal( format( pi, properties( "0.1", en ) ), "3.1" );
 
-	// Handle inaccurate floating point arithmetics like 0.00015 * 10000 = 1.49999999999999 before
-	// running the rounding function. See #376.
+	// Handle inaccurate floating point arithmetics like 0.00015 * 10000 = 1.49999999999999.
+	// See #376.
 	assert.equal( format( 0.00015, properties( "0.0001", en ) ), "0.0002" );
 });
 

--- a/test/unit/number/format.js
+++ b/test/unit/number/format.js
@@ -151,6 +151,10 @@ QUnit.test( "should allow rounding", function( assert ) {
 	assert.equal( format( pi, properties( "0.20", en ) ), "3.20" );
 	assert.equal( format( pi, properties( "0.5", en ) ), "3.0" );
 	assert.equal( format( pi, properties( "0.1", en ) ), "3.1" );
+
+	// Handle inaccurate floating point arithmetics like 0.00015 * 10000 = 1.49999999999999 before
+	// running the rounding function. See #376.
+	assert.equal( format( 0.00015, properties( "0.0001", en ) ), "0.0002" );
 });
 
 QUnit.test( "should allow different rounding options", function( assert ) {


### PR DESCRIPTION
JavaScript has a set of native math methods to perform number rounding: Math.ceil, Math.floor and Math.round. All of them return the number rounded to its nearest (ceil, floor or round) integer.

Rounding a decimal number on JavaScript is a three step process: shifting the decimal to a desired integer, rounding it and shifting the rounded number back to its original decimal order.

Currently, arithmetical operations `*` and `/` are used for shifting a number and for shifting it back. It happens these are subject to floating point inaccuracies. For example:
- `0.00015 * 10000 = 1.4999999999999998`;
- `1234 * 0.0001 = 0.12340000000000001`

Inaccurate floating point arithmetics lead to inaccurate roundings. In order to mitigate them, this change implements a custom way of performing both shifting and shifting back operations. Instead of multiplying the numbers by powers of 10, their floating point components are operated directly (summing or subtracting their exponents). Based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round and suggested by @stonys (Andrius Stonys).

Fixes #376