### PR TITLE
Add relative time formatting

### DIFF
--- a/src/build/intro-date.js
+++ b/src/build/intro-date.js
@@ -48,4 +48,5 @@ var createError = Globalize._createError,
 	validateDefaultLocale = Globalize._validateDefaultLocale,
 	validateParameterPresence = Globalize._validateParameterPresence,
 	validateParameterType = Globalize._validateParameterType,
-	validateParameterTypeString = Globalize._validateParameterTypeString;
+	validateParameterTypeString = Globalize._validateParameterTypeString,
+    validateParameterTypeNumber = Globalize._validateParameterTypeNumber;

--- a/src/build/intro-date.js
+++ b/src/build/intro-date.js
@@ -49,4 +49,4 @@ var createError = Globalize._createError,
 	validateParameterPresence = Globalize._validateParameterPresence,
 	validateParameterType = Globalize._validateParameterType,
 	validateParameterTypeString = Globalize._validateParameterTypeString,
-    validateParameterTypeNumber = Globalize._validateParameterTypeNumber;
+	validateParameterTypeNumber = Globalize._validateParameterTypeNumber;

--- a/src/core.js
+++ b/src/core.js
@@ -16,12 +16,13 @@ define([
 	"./util/object/extend",
 	"./util/regexp/escape",
 	"./util/string/pad",
+    "./util/cldr-format",
 
 	"cldr/event"
 ], function( Cldr, createError, formatMessage, validate, validateCldr, validateDefaultLocale,
 	validateParameterPresence, validateParameterRange, validateParameterType,
 	validateParameterTypeLocale, validateParameterTypePlainObject, alwaysArray, alwaysCldr,
-	isPlainObject, objectExtend, regexpEscape, stringPad ) {
+	isPlainObject, objectExtend, regexpEscape, stringPad, cldrFormat ) {
 
 function validateLikelySubtags( cldr ) {
 	cldr.once( "get", validateCldr );
@@ -101,6 +102,7 @@ Globalize._validateParameterPresence = validateParameterPresence;
 Globalize._validateParameterRange = validateParameterRange;
 Globalize._validateParameterTypePlainObject = validateParameterTypePlainObject;
 Globalize._validateParameterType = validateParameterType;
+Globalize._cldrFormat = cldrFormat;
 
 return Globalize;
 

--- a/src/core.js
+++ b/src/core.js
@@ -16,7 +16,7 @@ define([
 	"./util/object/extend",
 	"./util/regexp/escape",
 	"./util/string/pad",
-    "./util/cldr-format",
+	"./util/cldr-format",
 
 	"cldr/event"
 ], function( Cldr, createError, formatMessage, validate, validateCldr, validateDefaultLocale,

--- a/src/date.js
+++ b/src/date.js
@@ -7,7 +7,7 @@ define([
 	"./common/validate/parameter-type/date",
 	"./common/validate/parameter-type/date-pattern",
 	"./common/validate/parameter-type/string",
-    "./common/validate/parameter-type/number",
+	"./common/validate/parameter-type/number",
 	"./core",
 	"./date/expand-pattern",
 	"./date/format",
@@ -23,8 +23,8 @@ define([
 ], function( Cldr, validateCldr, validateDefaultLocale, validateParameterPresence,
 	validateParameterTypeDataType, validateParameterTypeDate, validateParameterTypeDatePattern,
 	validateParameterTypeString, validateParameterTypeNumber, Globalize, dateExpandPattern,
-    dateFormat, dateFormatProperties, dateParse, dateParseProperties, dateTokenizer,
-    dateTokenizerProperties ) {
+	dateFormat, dateFormatProperties, dateParse, dateParseProperties, dateTokenizer,
+	dateTokenizerProperties ) {
 
 function validateRequiredCldr( path, value ) {
 	validateCldr( path, value, {
@@ -167,31 +167,31 @@ Globalize.prototype.parseDate = function( value, pattern ) {
  */
 Globalize.getDay =
 Globalize.prototype.getDay = function(day, format) {
-    var rv,
-        cldr = this.cldr;
+	var rv,
+		cldr = this.cldr;
 
-    validateParameterPresence(day, "day");
-    validateParameterTypeString(day, "day");
-    validateParameterTypeString(format, "format");
+	validateParameterPresence(day, "day");
+	validateParameterTypeString(day, "day");
+	validateParameterTypeString(format, "format");
 
-    if (format === undefined) {
-        format = "wide";
-    }
+	if (format === undefined) {
+		format = "wide";
+	}
 
-    cldr.on( "get", validateRequiredCldr );
-    rv = cldr.main([ "dates/calendars/gregorian/days/stand-alone", format, day ]);
-    cldr.off( "get", validateRequiredCldr );
+	cldr.on( "get", validateRequiredCldr );
+	rv = cldr.main([ "dates/calendars/gregorian/days/stand-alone", format, day ]);
+	cldr.off( "get", validateRequiredCldr );
 
-    return rv;
+	return rv;
 };
 
 function relativeCountKey(count) {
-    if (count === 1) {
-        return "relativeTimePattern-count-one";
-    } else {
-        // TODO: should we look up correct pluralisms i.e. support more than one and other
-        return "relativeTimePattern-count-other";
-    }
+	if (count === 1) {
+		return "relativeTimePattern-count-one";
+	} else {
+		// TODO: should we look up correct pluralisms i.e. support more than one and other
+		return "relativeTimePattern-count-other";
+	}
 }
 
 /**
@@ -209,39 +209,39 @@ function relativeCountKey(count) {
  */
 Globalize.formatRelativeCount =
 Globalize.prototype.formatRelativeCount = function(type, count, maxWordOffset) {
-    var fmt, cldr, lookup;
+	var fmt, cldr, lookup;
 
-    validateParameterPresence(type, "type");
-    validateParameterTypeString(type, "type");
-    validateParameterPresence(count, "count");
-    validateParameterTypeNumber(count, "count");
-    validateParameterTypeNumber(maxWordOffset, "maxWordOffset");
+	validateParameterPresence(type, "type");
+	validateParameterTypeString(type, "type");
+	validateParameterPresence(count, "count");
+	validateParameterTypeNumber(count, "count");
+	validateParameterTypeNumber(maxWordOffset, "maxWordOffset");
 
-    if (maxWordOffset === undefined) {
-        maxWordOffset = 3;
-    }
-    lookup = [ "dates", "fields", type ];
-    cldr = this.cldr;
+	if (maxWordOffset === undefined) {
+		maxWordOffset = 3;
+	}
+	lookup = [ "dates", "fields", type ];
+	cldr = this.cldr;
 
-    if (Math.abs(count) <= maxWordOffset) {
-        fmt = cldr.main(lookup.concat([ "relative-type-" + count ]));
-        if (fmt !== undefined) {
-            return fmt;
-        }
-    }
+	if (Math.abs(count) <= maxWordOffset) {
+		fmt = cldr.main(lookup.concat([ "relative-type-" + count ]));
+		if (fmt !== undefined) {
+			return fmt;
+		}
+	}
 
-    if (count < 0) {
-        count =  Math.abs(count);
-        lookup.push("relativeTime-type-past");
-    } else if (count > 0) {
-        lookup.push("relativeTime-type-future");
-    }
-    lookup.push(relativeCountKey(count));
+	if (count < 0) {
+		count =  Math.abs(count);
+		lookup.push("relativeTime-type-past");
+	} else if (count > 0) {
+		lookup.push("relativeTime-type-future");
+	}
+	lookup.push(relativeCountKey(count));
 
-    cldr.on( "get", validateRequiredCldr );
-    fmt = cldr.main(lookup);
-    cldr.off( "get", validateRequiredCldr );
-    return Globalize._cldrFormat(fmt, count);
+	cldr.on( "get", validateRequiredCldr );
+	fmt = cldr.main(lookup);
+	cldr.off( "get", validateRequiredCldr );
+	return Globalize._cldrFormat(fmt, count);
 };
 
 return Globalize;

--- a/src/date.js
+++ b/src/date.js
@@ -183,6 +183,49 @@ Globalize.prototype.getDay = function(day, format) {
     return rv;
 };
 
+function relativeCountKey(count) {
+    if (count === 1) {
+        return "relativeTimePattern-count-one";
+    } else {
+        // TODO: should we look up correct pluralisms i.e. support more than one and other
+        return "relativeTimePattern-count-other";
+    }
+}
+
+/**
+ * .formatRelativeCount(type, count)
+ *
+ * @type [String] The type of time (day, week, month, quarter, year)
+ *  can optionally have -short or -narrow appended.
+ *
+ * @count [Number] The amount of time, negative for in the past;
+ *  positive for in the future. 0 is not currently handled
+ */
+Globalize.formatRelativeCount =
+Globalize.prototype.formatRelativeCount = function(type, count) {
+    var fmt,
+        cldr = this.cldr,
+        lookup = [ "dates", "fields", type ];
+
+    if (count < 0) {
+        count =  Math.abs(count);
+        lookup.push("relativeTime-type-past");
+        lookup.push(relativeCountKey(count));
+    } else if (count > 0) {
+        lookup.push("relativeTime-type-future");
+        lookup.push(relativeCountKey(count));
+    } else {
+        // TODO: what to do with zero
+        // we could return the appropriate word for today
+        throw new Error("Zero is not handled by formatRelativeCount");
+    }
+
+    cldr.on( "get", validateRequiredCldr );
+    fmt = cldr.main(lookup);
+    cldr.off( "get", validateRequiredCldr );
+    return Globalize._cldrFormat(fmt, count);
+};
+
 return Globalize;
 
 });

--- a/src/date.js
+++ b/src/date.js
@@ -153,6 +153,36 @@ Globalize.prototype.parseDate = function( value, pattern ) {
 	return this.dateParser( pattern )( value );
 };
 
+/**
+ * .getDay( day [, format] )
+ *
+ * Get the localised string for a day of the week.
+ *
+ * @value [String] a day key (mon, tue, etc.)
+ *
+ * @format [Optional String] a format for the day of the week wide, short or narrow
+ *  defaults to narrow
+ */
+Globalize.getDay =
+Globalize.prototype.getDay = function(day, format) {
+    var rv,
+        cldr = this.cldr;
+
+    validateParameterPresence(day, "day");
+    validateParameterTypeString(day, "day");
+    validateParameterTypeString(format, "format");
+
+    if (format === undefined) {
+        format = "wide";
+    }
+
+    cldr.on( "get", validateRequiredCldr );
+    rv = cldr.main([ "dates/calendars/gregorian/days/stand-alone", format, day ]);
+    cldr.off( "get", validateRequiredCldr );
+
+    return rv;
+};
+
 return Globalize;
 
 });

--- a/src/util/cldr-format.js
+++ b/src/util/cldr-format.js
@@ -1,10 +1,10 @@
 define(function() {
 
 return function(format) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    return format.replace(/{(\d+)}/g, function(match, number) {
-      return typeof args[number] !== "undefined" ? args[number] : match;
-    });
+	var args = Array.prototype.slice.call(arguments, 1);
+	return format.replace(/{(\d+)}/g, function(match, number) {
+	  return typeof args[number] !== "undefined" ? args[number] : match;
+	});
 };
 
 });

--- a/src/util/cldr-format.js
+++ b/src/util/cldr-format.js
@@ -1,0 +1,10 @@
+define(function() {
+
+return function(format) {
+    var args = Array.prototype.slice.call(arguments, 1);
+    return format.replace(/{(\d+)}/g, function(match, number) {
+      return typeof args[number] !== "undefined" ? args[number] : match;
+    });
+};
+
+});

--- a/test/functional.js
+++ b/test/functional.js
@@ -29,6 +29,7 @@ require([
 	"./functional/date/format-date",
 	"./functional/date/parse-date",
     "./functional/date/get-day",
+    "./functional/date/format-relative-count",
 
 	// message
 	"./functional/message/message-formatter",

--- a/test/functional.js
+++ b/test/functional.js
@@ -28,8 +28,8 @@ require([
 	"./functional/date/date-parser",
 	"./functional/date/format-date",
 	"./functional/date/parse-date",
-    "./functional/date/get-day",
-    "./functional/date/format-relative-count",
+	"./functional/date/get-day",
+	"./functional/date/format-relative-count",
 
 	// message
 	"./functional/message/message-formatter",

--- a/test/functional.js
+++ b/test/functional.js
@@ -28,6 +28,7 @@ require([
 	"./functional/date/date-parser",
 	"./functional/date/format-date",
 	"./functional/date/parse-date",
+    "./functional/date/get-day",
 
 	// message
 	"./functional/message/message-formatter",

--- a/test/functional/date/format-relative-count.js
+++ b/test/functional/date/format-relative-count.js
@@ -1,0 +1,61 @@
+define([
+    "globalize",
+    "json!cldr-data/main/en/dateFields.json",
+    "json!cldr-data/main/de/dateFields.json",
+    "json!cldr-data/supplemental/likelySubtags.json",
+    "../../util",
+
+    "globalize/date"
+], function( Globalize, enDateFields, deDateFields, likelySubtags, util ) {
+
+QUnit.module( "fomatRelativeCount function (no cldr)", {
+    setup: function() {
+        Globalize.load( likelySubtags, {
+            main: {
+                en: {}
+            }
+        });
+        Globalize.locale( "en" );
+    },
+    teardown: util.resetCldrContent
+});
+
+QUnit.test( "should validate CLDR content", function( assert ) {
+    util.assertCldrContent( assert, function() {
+        Globalize.formatRelativeCount("day", "1");
+    });
+});
+
+var en, de;
+
+QUnit.module( "formatRelativeCount function", {
+    setup: function() {
+        Globalize.load( likelySubtags, enDateFields, deDateFields);
+        Globalize.locale( "en" );
+        en = new Globalize( "en" );
+        de = new Globalize( "de" );
+    },
+    teardown: util.resetCldrContent
+} );
+
+QUnit.test( "should format 1 day ago", function( assert ) {
+    assert.equal( en.formatRelativeCount("day", -1), "1 day ago" );
+});
+
+QUnit.test( "should format 2 weeks ago", function( assert ) {
+    assert.equal( en.formatRelativeCount("week", -2), "2 weeks ago" );
+});
+
+QUnit.test( "should format german 1 day ago", function( assert ) {
+    assert.equal( de.formatRelativeCount("day", -1), "vor 1 Tag" );
+});
+
+QUnit.test( "should format 1 wk. ago", function( assert ) {
+    assert.equal( en.formatRelativeCount("week-short", -1), "1 wk. ago" );
+});
+
+QUnit.test( "should format in 3 years", function ( assert ) {
+    assert.equal( en.formatRelativeCount("year", 3), "in 3 years");
+});
+
+});

--- a/test/functional/date/format-relative-count.js
+++ b/test/functional/date/format-relative-count.js
@@ -5,6 +5,7 @@ define([
     "json!cldr-data/supplemental/likelySubtags.json",
     "../../util",
 
+    "globalize/number",
     "globalize/date"
 ], function( Globalize, enDateFields, deDateFields, likelySubtags, util ) {
 
@@ -22,7 +23,7 @@ QUnit.module( "fomatRelativeCount function (no cldr)", {
 
 QUnit.test( "should validate CLDR content", function( assert ) {
     util.assertCldrContent( assert, function() {
-        Globalize.formatRelativeCount("day", "1");
+        Globalize.formatRelativeCount("day", 1);
     });
 });
 
@@ -38,8 +39,44 @@ QUnit.module( "formatRelativeCount function", {
     teardown: util.resetCldrContent
 } );
 
+QUnit.test( "should validate type argument presence", function( assert ) {
+    util.assertParameterPresence( assert, "type", function() {
+        Globalize.formatRelativeCount( );
+    });
+});
+
+QUnit.test( "should validate type argument is string", function( assert ) {
+    util.assertStringParameter( assert, "type", function(invalidValue) {
+        return function() {
+            Globalize.formatRelativeCount(invalidValue, 0);
+        };
+    });
+});
+
+QUnit.test( "should validate count argument presence", function( assert ) {
+    util.assertParameterPresence( assert, "count", function() {
+        Globalize.formatRelativeCount( "day" );
+    });
+});
+
+QUnit.test( "should validate count argument is number", function( assert ) {
+    util.assertNumberParameter( assert, "count", function(invalidValue) {
+        return function() {
+            Globalize.formatRelativeCount("day", invalidValue);
+        };
+    });
+});
+
+QUnit.test( "should validate maxWordOffset argument is number", function( assert ) {
+    util.assertNumberParameter( assert, "maxWordOffset", function(invalidValue) {
+        return function() {
+            Globalize.formatRelativeCount("day", 1, invalidValue);
+        };
+    });
+});
+
 QUnit.test( "should format 1 day ago", function( assert ) {
-    assert.equal( en.formatRelativeCount("day", -1), "1 day ago" );
+    assert.equal( en.formatRelativeCount("day", -1, 0), "1 day ago" );
 });
 
 QUnit.test( "should format 2 weeks ago", function( assert ) {
@@ -47,15 +84,27 @@ QUnit.test( "should format 2 weeks ago", function( assert ) {
 });
 
 QUnit.test( "should format german 1 day ago", function( assert ) {
-    assert.equal( de.formatRelativeCount("day", -1), "vor 1 Tag" );
+    assert.equal( de.formatRelativeCount("day", -1, 0), "vor 1 Tag" );
 });
 
 QUnit.test( "should format 1 wk. ago", function( assert ) {
-    assert.equal( en.formatRelativeCount("week-short", -1), "1 wk. ago" );
+    assert.equal( en.formatRelativeCount("week-short", -1, 0), "1 wk. ago" );
 });
 
 QUnit.test( "should format in 3 years", function ( assert ) {
     assert.equal( en.formatRelativeCount("year", 3), "in 3 years");
+});
+
+QUnit.test( "should format today", function( assert ) {
+    assert.equal( en.formatRelativeCount("day", 0), "today" );
+});
+
+QUnit.test( "should format tomorrow", function( assert ) {
+    assert.equal( en.formatRelativeCount("day", 1), "tomorrow" );
+});
+
+QUnit.test( "should format the day after tomorrow in german", function( assert ) {
+    assert.equal( de.formatRelativeCount("day", 2), "übermorgen" );
 });
 
 });

--- a/test/functional/date/format-relative-count.js
+++ b/test/functional/date/format-relative-count.js
@@ -1,110 +1,110 @@
 define([
-    "globalize",
-    "json!cldr-data/main/en/dateFields.json",
-    "json!cldr-data/main/de/dateFields.json",
-    "json!cldr-data/supplemental/likelySubtags.json",
-    "../../util",
+	"globalize",
+	"json!cldr-data/main/en/dateFields.json",
+	"json!cldr-data/main/de/dateFields.json",
+	"json!cldr-data/supplemental/likelySubtags.json",
+	"../../util",
 
-    "globalize/number",
-    "globalize/date"
+	"globalize/number",
+	"globalize/date"
 ], function( Globalize, enDateFields, deDateFields, likelySubtags, util ) {
 
 QUnit.module( "fomatRelativeCount function (no cldr)", {
-    setup: function() {
-        Globalize.load( likelySubtags, {
-            main: {
-                en: {}
-            }
-        });
-        Globalize.locale( "en" );
-    },
-    teardown: util.resetCldrContent
+	setup: function() {
+		Globalize.load( likelySubtags, {
+			main: {
+				en: {}
+			}
+		});
+		Globalize.locale( "en" );
+	},
+	teardown: util.resetCldrContent
 });
 
 QUnit.test( "should validate CLDR content", function( assert ) {
-    util.assertCldrContent( assert, function() {
-        Globalize.formatRelativeCount("day", 1);
-    });
+	util.assertCldrContent( assert, function() {
+		Globalize.formatRelativeCount("day", 1);
+	});
 });
 
 var en, de;
 
 QUnit.module( "formatRelativeCount function", {
-    setup: function() {
-        Globalize.load( likelySubtags, enDateFields, deDateFields);
-        Globalize.locale( "en" );
-        en = new Globalize( "en" );
-        de = new Globalize( "de" );
-    },
-    teardown: util.resetCldrContent
+	setup: function() {
+		Globalize.load( likelySubtags, enDateFields, deDateFields);
+		Globalize.locale( "en" );
+		en = new Globalize( "en" );
+		de = new Globalize( "de" );
+	},
+	teardown: util.resetCldrContent
 } );
 
 QUnit.test( "should validate type argument presence", function( assert ) {
-    util.assertParameterPresence( assert, "type", function() {
-        Globalize.formatRelativeCount( );
-    });
+	util.assertParameterPresence( assert, "type", function() {
+		Globalize.formatRelativeCount( );
+	});
 });
 
 QUnit.test( "should validate type argument is string", function( assert ) {
-    util.assertStringParameter( assert, "type", function(invalidValue) {
-        return function() {
-            Globalize.formatRelativeCount(invalidValue, 0);
-        };
-    });
+	util.assertStringParameter( assert, "type", function(invalidValue) {
+		return function() {
+			Globalize.formatRelativeCount(invalidValue, 0);
+		};
+	});
 });
 
 QUnit.test( "should validate count argument presence", function( assert ) {
-    util.assertParameterPresence( assert, "count", function() {
-        Globalize.formatRelativeCount( "day" );
-    });
+	util.assertParameterPresence( assert, "count", function() {
+		Globalize.formatRelativeCount( "day" );
+	});
 });
 
 QUnit.test( "should validate count argument is number", function( assert ) {
-    util.assertNumberParameter( assert, "count", function(invalidValue) {
-        return function() {
-            Globalize.formatRelativeCount("day", invalidValue);
-        };
-    });
+	util.assertNumberParameter( assert, "count", function(invalidValue) {
+		return function() {
+			Globalize.formatRelativeCount("day", invalidValue);
+		};
+	});
 });
 
 QUnit.test( "should validate maxWordOffset argument is number", function( assert ) {
-    util.assertNumberParameter( assert, "maxWordOffset", function(invalidValue) {
-        return function() {
-            Globalize.formatRelativeCount("day", 1, invalidValue);
-        };
-    });
+	util.assertNumberParameter( assert, "maxWordOffset", function(invalidValue) {
+		return function() {
+			Globalize.formatRelativeCount("day", 1, invalidValue);
+		};
+	});
 });
 
 QUnit.test( "should format 1 day ago", function( assert ) {
-    assert.equal( en.formatRelativeCount("day", -1, 0), "1 day ago" );
+	assert.equal( en.formatRelativeCount("day", -1, 0), "1 day ago" );
 });
 
 QUnit.test( "should format 2 weeks ago", function( assert ) {
-    assert.equal( en.formatRelativeCount("week", -2), "2 weeks ago" );
+	assert.equal( en.formatRelativeCount("week", -2), "2 weeks ago" );
 });
 
 QUnit.test( "should format german 1 day ago", function( assert ) {
-    assert.equal( de.formatRelativeCount("day", -1, 0), "vor 1 Tag" );
+	assert.equal( de.formatRelativeCount("day", -1, 0), "vor 1 Tag" );
 });
 
 QUnit.test( "should format 1 wk. ago", function( assert ) {
-    assert.equal( en.formatRelativeCount("week-short", -1, 0), "1 wk. ago" );
+	assert.equal( en.formatRelativeCount("week-short", -1, 0), "1 wk. ago" );
 });
 
 QUnit.test( "should format in 3 years", function ( assert ) {
-    assert.equal( en.formatRelativeCount("year", 3), "in 3 years");
+	assert.equal( en.formatRelativeCount("year", 3), "in 3 years");
 });
 
 QUnit.test( "should format today", function( assert ) {
-    assert.equal( en.formatRelativeCount("day", 0), "today" );
+	assert.equal( en.formatRelativeCount("day", 0), "today" );
 });
 
 QUnit.test( "should format tomorrow", function( assert ) {
-    assert.equal( en.formatRelativeCount("day", 1), "tomorrow" );
+	assert.equal( en.formatRelativeCount("day", 1), "tomorrow" );
 });
 
 QUnit.test( "should format the day after tomorrow in german", function( assert ) {
-    assert.equal( de.formatRelativeCount("day", 2), "übermorgen" );
+	assert.equal( de.formatRelativeCount("day", 2), "übermorgen" );
 });
 
 });

--- a/test/functional/date/get-day.js
+++ b/test/functional/date/get-day.js
@@ -1,0 +1,86 @@
+define([
+    "globalize",
+    "json!cldr-data/main/en/ca-gregorian.json",
+    "json!cldr-data/main/de/ca-gregorian.json",
+    "json!cldr-data/supplemental/likelySubtags.json",
+    "../../util",
+
+    "globalize/date"
+], function( Globalize, enCaGregorian, deCaGregorian, likelySubtags, util ) {
+
+QUnit.module( "getDay function (no cldr)", {
+    setup: function() {
+        Globalize.load( likelySubtags, {
+            main: {
+                en: {}
+            }
+        });
+        Globalize.locale( "en" );
+    },
+    teardown: util.resetCldrContent
+} );
+
+QUnit.test( "should validate CLDR content", function( assert ) {
+    util.assertCldrContent( assert, function() {
+        Globalize.getDay( "sun" );
+    });
+});
+
+QUnit.test( "should validate day argument presence", function( assert ) {
+    util.assertParameterPresence( assert, "day", function() {
+        Globalize.getDay( );
+    });
+});
+
+QUnit.test( "should validate day argument is string", function( assert ) {
+    util.assertStringParameter( assert, "day", function(invalidValue) {
+        return function() {
+            Globalize.getDay(invalidValue);
+        };
+    });
+});
+
+QUnit.test( "should validate format argument is string", function( assert ) {
+    util.assertStringParameter( assert, "format", function(invalidValue) {
+        return function() {
+            Globalize.getDay("sun", invalidValue);
+        };
+    });
+});
+
+var en, de;
+QUnit.module( "getDay function", {
+    setup: function() {
+        Globalize.load( enCaGregorian, deCaGregorian, likelySubtags );
+        Globalize.locale( "en" );
+        en = new Globalize( "en" );
+        de = new Globalize( "de" );
+    },
+    teardown: util.resetCldrContent
+});
+
+QUnit.test( "should return an default locale day", function( assert ) {
+    assert.equal( Globalize.getDay("wed"), "Wednesday" );
+});
+
+QUnit.test( "should return an english day asked", function( assert ) {
+    assert.equal( en.getDay("sun"), "Sunday" );
+});
+
+QUnit.test( "should return an german day asked", function( assert ) {
+    assert.equal( de.getDay("mon"), "Montag" );
+});
+
+QUnit.test( "should return a wide day if asked explicitly", function( assert ) {
+    assert.equal( de.getDay("tue", "wide"), "Dienstag" );
+});
+
+QUnit.test( "should return a short day asked", function( assert ) {
+    assert.equal( de.getDay("sun", "short"), "So." );
+});
+
+QUnit.test( "should return a short day asked", function( assert ) {
+    assert.equal( Globalize.getDay("sun", "narrow"), "S" );
+});
+
+});

--- a/test/functional/date/get-day.js
+++ b/test/functional/date/get-day.js
@@ -1,86 +1,86 @@
 define([
-    "globalize",
-    "json!cldr-data/main/en/ca-gregorian.json",
-    "json!cldr-data/main/de/ca-gregorian.json",
-    "json!cldr-data/supplemental/likelySubtags.json",
-    "../../util",
+	"globalize",
+	"json!cldr-data/main/en/ca-gregorian.json",
+	"json!cldr-data/main/de/ca-gregorian.json",
+	"json!cldr-data/supplemental/likelySubtags.json",
+	"../../util",
 
-    "globalize/date"
+	"globalize/date"
 ], function( Globalize, enCaGregorian, deCaGregorian, likelySubtags, util ) {
 
 QUnit.module( "getDay function (no cldr)", {
-    setup: function() {
-        Globalize.load( likelySubtags, {
-            main: {
-                en: {}
-            }
-        });
-        Globalize.locale( "en" );
-    },
-    teardown: util.resetCldrContent
+	setup: function() {
+		Globalize.load( likelySubtags, {
+			main: {
+				en: {}
+			}
+		});
+		Globalize.locale( "en" );
+	},
+	teardown: util.resetCldrContent
 } );
 
 QUnit.test( "should validate CLDR content", function( assert ) {
-    util.assertCldrContent( assert, function() {
-        Globalize.getDay( "sun" );
-    });
+	util.assertCldrContent( assert, function() {
+		Globalize.getDay( "sun" );
+	});
 });
 
 QUnit.test( "should validate day argument presence", function( assert ) {
-    util.assertParameterPresence( assert, "day", function() {
-        Globalize.getDay( );
-    });
+	util.assertParameterPresence( assert, "day", function() {
+		Globalize.getDay( );
+	});
 });
 
 QUnit.test( "should validate day argument is string", function( assert ) {
-    util.assertStringParameter( assert, "day", function(invalidValue) {
-        return function() {
-            Globalize.getDay(invalidValue);
-        };
-    });
+	util.assertStringParameter( assert, "day", function(invalidValue) {
+		return function() {
+			Globalize.getDay(invalidValue);
+		};
+	});
 });
 
 QUnit.test( "should validate format argument is string", function( assert ) {
-    util.assertStringParameter( assert, "format", function(invalidValue) {
-        return function() {
-            Globalize.getDay("sun", invalidValue);
-        };
-    });
+	util.assertStringParameter( assert, "format", function(invalidValue) {
+		return function() {
+			Globalize.getDay("sun", invalidValue);
+		};
+	});
 });
 
 var en, de;
 QUnit.module( "getDay function", {
-    setup: function() {
-        Globalize.load( enCaGregorian, deCaGregorian, likelySubtags );
-        Globalize.locale( "en" );
-        en = new Globalize( "en" );
-        de = new Globalize( "de" );
-    },
-    teardown: util.resetCldrContent
+	setup: function() {
+		Globalize.load( enCaGregorian, deCaGregorian, likelySubtags );
+		Globalize.locale( "en" );
+		en = new Globalize( "en" );
+		de = new Globalize( "de" );
+	},
+	teardown: util.resetCldrContent
 });
 
 QUnit.test( "should return an default locale day", function( assert ) {
-    assert.equal( Globalize.getDay("wed"), "Wednesday" );
+	assert.equal( Globalize.getDay("wed"), "Wednesday" );
 });
 
 QUnit.test( "should return an english day asked", function( assert ) {
-    assert.equal( en.getDay("sun"), "Sunday" );
+	assert.equal( en.getDay("sun"), "Sunday" );
 });
 
 QUnit.test( "should return an german day asked", function( assert ) {
-    assert.equal( de.getDay("mon"), "Montag" );
+	assert.equal( de.getDay("mon"), "Montag" );
 });
 
 QUnit.test( "should return a wide day if asked explicitly", function( assert ) {
-    assert.equal( de.getDay("tue", "wide"), "Dienstag" );
+	assert.equal( de.getDay("tue", "wide"), "Dienstag" );
 });
 
 QUnit.test( "should return a short day asked", function( assert ) {
-    assert.equal( de.getDay("sun", "short"), "So." );
+	assert.equal( de.getDay("sun", "short"), "So." );
 });
 
 QUnit.test( "should return a short day asked", function( assert ) {
-    assert.equal( Globalize.getDay("sun", "narrow"), "S" );
+	assert.equal( Globalize.getDay("sun", "narrow"), "S" );
 });
 
 });

--- a/test/unit.js
+++ b/test/unit.js
@@ -12,8 +12,8 @@ require.config({
 });
 
 require([
-    // util
-    "./unit/util/cldr-format.js",
+	// util
+	"./unit/util/cldr-format.js",
 
 	// core
 	"./unit/core",

--- a/test/unit.js
+++ b/test/unit.js
@@ -12,6 +12,8 @@ require.config({
 });
 
 require([
+    // util
+    "./unit/util/cldr-format.js",
 
 	// core
 	"./unit/core",

--- a/test/unit/util/cldr-format.js
+++ b/test/unit/util/cldr-format.js
@@ -1,19 +1,19 @@
 define([
-    "src/util/cldr-format"
+	"src/util/cldr-format"
 ], function (cldrFormat) {
 
-    QUnit.module( "CLDR {0} style string formatter" );
+QUnit.module( "CLDR {0} style string formatter" );
 
-    QUnit.test( "should handle strings with no formatting", function( assert ) {
-        assert.equal( cldrFormat("hello"), "hello" );
-    });
+QUnit.test( "should handle strings with no formatting", function( assert ) {
+	assert.equal( cldrFormat("hello"), "hello" );
+});
 
-    QUnit.test( "should handle strings with a formatting", function( assert ) {
-        assert.equal( cldrFormat("hello {0}", "world"), "hello world" );
-    });
+QUnit.test( "should handle strings with a formatting", function( assert ) {
+	assert.equal( cldrFormat("hello {0}", "world"), "hello world" );
+});
 
-    QUnit.test( "should handle strings with a couple format specifiers", function( assert ) {
-        assert.equal( cldrFormat("{1} {0}", "dog", "down"), "down dog" );
-    });
+QUnit.test( "should handle strings with a couple format specifiers", function( assert ) {
+	assert.equal( cldrFormat("{1} {0}", "dog", "down"), "down dog" );
+});
 
 });

--- a/test/unit/util/cldr-format.js
+++ b/test/unit/util/cldr-format.js
@@ -1,0 +1,19 @@
+define([
+    "src/util/cldr-format"
+], function (cldrFormat) {
+
+    QUnit.module( "CLDR {0} style string formatter" );
+
+    QUnit.test( "should handle strings with no formatting", function( assert ) {
+        assert.equal( cldrFormat("hello"), "hello" );
+    });
+
+    QUnit.test( "should handle strings with a formatting", function( assert ) {
+        assert.equal( cldrFormat("hello {0}", "world"), "hello world" );
+    });
+
+    QUnit.test( "should handle strings with a couple format specifiers", function( assert ) {
+        assert.equal( cldrFormat("{1} {0}", "dog", "down"), "down dog" );
+    });
+
+});


### PR DESCRIPTION
Hi,

I wrote a couple of functions for formatting some date related things based on the cldr data. 
getDay just looks up the names of days in the cldr data. (and supports the different formats that cldr supports)
formatRelativeCount formats an amount of time in a relative way. e.g. if you ask for 3 days in the past it will return 3 days ago. It tries to use words like today and tomorrow if available.