### PR TITLE
Message: Add inline commented variables argument

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -111,7 +111,7 @@ Globalize.prototype.messageFormatter = function( path ) {
  * Format a message given its path.
  */
 Globalize.formatMessage =
-Globalize.prototype.formatMessage = function( path ) {
+Globalize.prototype.formatMessage = function( path /* , variables */ ) {
 	return this.messageFormatter( path ).apply( {}, slice.call( arguments, 1 ) );
 };
 


### PR DESCRIPTION
This makes it clearer for someone reading the source to know what is being passed on to messageFormatter without upsetting JSHint with an unused argument. It also allows folks building things on top of Globalize and parsing the source, like myself, to get an accurate picture of the API from the source.