### PR TITLE
Docs: removal of invalid reference to html

### DIFF
--- a/examples/node-npm/README.md
+++ b/examples/node-npm/README.md
@@ -54,5 +54,4 @@ information, see [npm's cldr-data](https://github.com/rxaviers/cldr-data-npm).
 Once you've completed the requirements above:
 
 1. Run `node main.js`.
-1. Understand the demo by reading the source code (both index.html and main.js).
-We have comments there for you.
+1. Understand the demo by reading the source code. We have comments there for you.


### PR DESCRIPTION
Something small I spotted whilst browsing the examples