### PR TITLE
Build: Update to QUnit 1.18, load it via AMD as well

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,8 @@ module.exports = function( grunt ) {
 				}
 			},
 			test: {
-				src: [ "test/*.js", "test/functional/**/*.js", "test/unit/**/*.js" ],
+				src: [ "test/*.js", "test/functional/**/*.js", "test/unit/**/*.js",
+					"!test/config.js" ],
 				options: {
 					jshintrc: "test/.jshintrc"
 				}

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "es5-shim": "3.4.0",
     "make-plural": "eemeli/make-plural.js#2.1.2",
     "messageformat": "SlexAxton/messageformat.js#debeaf4",
-    "qunit": "1.16.0",
+    "qunit": "1.18.0",
     "requirejs": "2.1.9",
     "requirejs-plugins": "1.0.2",
     "requirejs-text": "2.0.10"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "grunt-contrib-connect": "0.8.0",
     "grunt-contrib-copy": "0.6.0",
     "grunt-contrib-jshint": "0.10.0",
-    "grunt-contrib-qunit": "0.5.2",
+    "grunt-contrib-qunit": "0.7.0",
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-uglify": "0.6.0",
     "grunt-contrib-watch": "0.6.1",

--- a/test/config.js
+++ b/test/config.js
@@ -1,0 +1,14 @@
+var requirejs = {
+	paths: {
+		qunit: "../external/qunit/qunit/qunit",
+		cldr: "../external/cldrjs/dist/cldr",
+		"cldr-data": "../external/cldr-data",
+		globalize: "../dist/globalize",
+		json: "../external/requirejs-plugins/src/json",
+		src: "../src",
+		text: "../external/requirejs-text/text"
+	},
+
+	// Increase the default of 7 seconds for high-latency envs like browserstack-runner.
+	waitSeconds: 60
+};

--- a/test/functional-es5-shim.html
+++ b/test/functional-es5-shim.html
@@ -10,11 +10,7 @@
     <div id="qunit-fixture"></div>
 
     <script src="../external/es5-shim/es5-shim.js"></script>
-    <script src="../external/qunit/qunit/qunit.js"></script>
-    <script>
-    QUnit.config.autostart = false;
-    </script>
-
+    <script src="config.js"></script>
     <script data-main="functional.js" src="../external/requirejs/require.js"></script>
 </body>
 </html>

--- a/test/functional.html
+++ b/test/functional.html
@@ -10,11 +10,7 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
 
-    <script src="../external/qunit/qunit/qunit.js"></script>
-    <script>
-    QUnit.config.autostart = false;
-    </script>
-
+    <script src="config.js"></script>
     <script data-main="functional.js" src="../external/requirejs/require.js"></script>
 </body>
 </html>

--- a/test/functional.js
+++ b/test/functional.js
@@ -1,18 +1,5 @@
-require.config({
-	paths: {
-		cldr: "../external/cldrjs/dist/cldr",
-		"cldr-data": "../external/cldr-data",
-		globalize: "../dist/globalize",
-		json: "../external/requirejs-plugins/src/json",
-		src: "../src",
-		text: "../external/requirejs-text/text"
-	},
-
-	// Increase the default of 7 seconds for high-latency envs like browserstack-runner.
-	waitSeconds: 30
-});
-
 require([
+	"qunit",
 
 	// core
 	"./functional/core",

--- a/test/unit-es5-shim.html
+++ b/test/unit-es5-shim.html
@@ -10,11 +10,7 @@
     <div id="qunit-fixture"></div>
 
     <script src="../external/es5-shim/es5-shim.js"></script>
-    <script src="../external/qunit/qunit/qunit.js"></script>
-    <script>
-    QUnit.config.autostart = false;
-    </script>
-
+    <script src="config.js"></script>
     <script data-main="unit.js" src="../external/requirejs/require.js"></script>
 </body>
 </html>

--- a/test/unit.html
+++ b/test/unit.html
@@ -10,11 +10,7 @@
     <div id="qunit"></div>
     <div id="qunit-fixture"></div>
 
-    <script src="../external/qunit/qunit/qunit.js"></script>
-    <script>
-    QUnit.config.autostart = false;
-    </script>
-
+    <script src="config.js"></script>
     <script data-main="unit.js" src="../external/requirejs/require.js"></script>
 </body>
 </html>

--- a/test/unit.js
+++ b/test/unit.js
@@ -1,17 +1,5 @@
-require.config({
-	paths: {
-		cldr: "../external/cldrjs/dist/cldr",
-		"cldr-data": "../external/cldr-data",
-		json: "../external/requirejs-plugins/src/json",
-		src: "../src",
-		text: "../external/requirejs-text/text"
-	},
-
-	// Increase the default of 7 seconds for high-latency envs like browserstack-runner.
-	waitSeconds: 30
-});
-
 require([
+	"qunit",
 
 	// core
 	"./unit/core",

--- a/test/unit/currency/name-format.js
+++ b/test/unit/currency/name-format.js
@@ -28,7 +28,7 @@ Cldr.load(
 en = new Cldr( "en" );
 zh = new Cldr( "zh" );
 
-QUnit.module( "Currency Name Foramt" );
+QUnit.module( "Currency Name Format" );
 
 QUnit.test( "should return appropriate properties", function( assert ) {
 	assert.deepEqual( format( "1", "one", properties( "USD", en ) ), "1 US dollar" );


### PR DESCRIPTION
Extract requirejs configuration into separate file. Load synchronosly
for the grunt-contrib-qunit bridge to be able to use it as well.

Increase the waitTimeout to make it work on with browserstack-runner - need to verify it now works reliable, could then also merge #381.

Also fix a typo in a module name.