### PR TITLE
Documentation: Add link to globalize-express - An ExpressJS middleware for Globalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Node.js module.
   - [Requirements](#requirements)
   - [Installation](#installation)
   - [Usage](#usage)
+    - [Express Middleware](#using-it-with-express)
 - [API](#api)
   - [Core](#core-module)
   - [Date module](#date-module)
@@ -252,6 +253,9 @@ to you in different flavors):
 - [Hello World (Node.js + npm)](examples/node-npm/).
 - [Hello World (plain JavaScript)](examples/plain-javascript/).
 
+#### Using it with Express
+
+Checkout the [globalize-express](https://github.com/devangnegandhi/globalize-express) middleware to use Gloablize in your express web application.
 
 ## API
 


### PR DESCRIPTION
I have written an ExpressJS middleware that makes it easy for developers of web applications to use Globalize within their express app. You can checkout the project here - https://github.com/devangnegandhi/globalize-express. 

I think this is a very useful expressJS middleware that will benefit lot of developers that want to use Globalize in their web applications. The project is well tested and I feel adding a link to this on the jquery/Globalize github page would help people discover it. 