### PR TITLE
Avoid re-using a variable for a different purpose

### DIFF
--- a/src/currency/supplemental-override.js
+++ b/src/currency/supplemental-override.js
@@ -9,15 +9,14 @@ define([
  */
 return function( currency, pattern, cldr ) {
 	var digits,
-		fraction = cldr.supplemental([ "currencyData/fractions", currency ]) ||
+		fraction = "",
+		fractionData = cldr.supplemental([ "currencyData/fractions", currency ]) ||
 			cldr.supplemental( "currencyData/fractions/DEFAULT" );
 
-	digits = +fraction._digits;
+	digits = +fractionData._digits;
 
 	if ( digits ) {
-		fraction = "." + stringPad( "0", digits ).slice( 0, -1 ) + fraction._rounding;
-	} else {
-		fraction = "";
+		fraction = "." + stringPad( "0", digits ).slice( 0, -1 ) + fractionData._rounding;
 	}
 
 	return pattern.replace( /\.(#+|0*[0-9]|0+[0-9]?)/g, fraction );


### PR DESCRIPTION
fraction starts off as an object then becomes a string