### PR TITLE
Number: Add padding zero to leading decimal

### DIFF
--- a/src/number/parse.js
+++ b/src/number/parse.js
@@ -62,7 +62,7 @@ return function( value, properties ) {
 			});
 		}
 
-		// Ad padding zero to leading decimal
+		// Add padding zero to leading decimal
 		if ( value.charAt( 0 ) === "." ) {
 			value = "0" + value;
 		}

--- a/src/number/parse.js
+++ b/src/number/parse.js
@@ -62,7 +62,7 @@ return function( value, properties ) {
 			});
 		}
 
-		// Add padding zero to leading decimal
+		// Add padding zero to leading decimal.
 		if ( value.charAt( 0 ) === "." ) {
 			value = "0" + value;
 		}

--- a/src/number/parse.js
+++ b/src/number/parse.js
@@ -62,6 +62,11 @@ return function( value, properties ) {
 			});
 		}
 
+		// Ad padding zero to leading decimal
+		if ( value.charAt( 0 ) === "." ) {
+			value = "0" + value;
+		}
+
 		// Is it a valid number?
 		value = value.match( numberNumberRe );
 		if ( !value ) {

--- a/test/unit/number/parse.js
+++ b/test/unit/number/parse.js
@@ -5,6 +5,7 @@ define([
 	"json!cldr-data/main/ar/numbers.json",
 	"json!cldr-data/main/en/numbers.json",
 	"json!cldr-data/main/es/numbers.json",
+	"json!cldr-data/main/pt/numbers.json",
 	"json!cldr-data/main/ru/numbers.json",
 	"json!cldr-data/main/sv/numbers.json",
 	"json!cldr-data/main/zh/numbers.json",
@@ -13,15 +14,16 @@ define([
 
 	"cldr/event",
 	"cldr/supplemental"
-], function( Cldr, parse, properties, arNumbers, enNumbers, esNumbers, ruNumbers, svNumbers,
-	zhNumbers, likelySubtags, numberingSystems ) {
+], function( Cldr, parse, properties, arNumbers, enNumbers, esNumbers, ptNumbers, ruNumbers,
+	svNumbers, zhNumbers, likelySubtags, numberingSystems ) {
 
-var ar, en, es, ru, sv, zh;
+var ar, en, es, pt, ru, sv, zh;
 
 Cldr.load(
 	arNumbers,
 	enNumbers,
 	esNumbers,
+	ptNumbers,
 	ruNumbers,
 	svNumbers,
 	zhNumbers,
@@ -32,6 +34,7 @@ Cldr.load(
 ar = new Cldr( "ar" );
 en = new Cldr( "en" );
 es = new Cldr( "es" );
+pt = new Cldr( "pt" );
 ru = new Cldr( "sv" );
 sv = new Cldr( "sv" );
 zh = new Cldr( "zh-u-nu-native" );
@@ -81,6 +84,8 @@ QUnit.test( "should parse zero-padded decimals", function( assert ) {
 QUnit.test( "should parse non-padded decimals", function( assert ) {
 	assert.equal( parse( ".14159", properties( "0.0", en ) ), 0.14159 );
 	assert.equal( parse( ".752", properties( "0.0", en ) ), 0.752 );
+	assert.equal( parse( "٫١٤١٥٩", properties( "0.0", ar ) ), 0.14159 );
+	assert.equal( parse( ",752", properties( "0.0", pt ) ), 0.752 );
 });
 
 QUnit.test( "should parse negative decimal", function( assert ) {

--- a/test/unit/number/parse.js
+++ b/test/unit/number/parse.js
@@ -78,13 +78,18 @@ QUnit.test( "should parse zero-padded decimals", function( assert ) {
 	assert.equal( parse( "0.10", properties( "0.00", en ) ), 0.1 );
 });
 
+QUnit.test( "should parse non-padded decimals", function( assert ) {
+	assert.equal( parse( ".14159", properties( "0.0", en ) ), 0.14159 );
+	assert.equal( parse( ".752", properties( "0.0", en ) ), 0.752 );
+});
+
 QUnit.test( "should parse negative decimal", function( assert ) {
 	assert.equal( parse( "-3.14", properties( "0.##", en ) ), -3.14 );
 	assert.equal( parse( "(3.14)", properties( "0.##;(0.##)", en ) ), -3.14 );
 });
 
 QUnit.test( "should not parse too permissive", function( assert ) {
-	assert.deepEqual( parse( "3.14", properties( "0.##", ru ) ), NaN ); 
+	assert.deepEqual( parse( "3.14", properties( "0.##", ru ) ), NaN );
 });
 
 /**


### PR DESCRIPTION
Fixes #443
Ref #353
Ref #454
Ref #517 

I know this isn't an ideal solution, but adding a padding zero is way easier than trying to modify the regular expression, then adapting the code that depends on the matches.

New unit tests were added, and all passing.