### PR TITLE
Fixes #487

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Jörn Zaefferer <joern.zaefferer@gmail.com>
+Richard D. Worth <rdworth@gmail.com>

--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,10 @@
+Dave Reed <dareed@microsoft.com>
+Stephen Walther <Swalther@Microsoft.com>
+John Resig <jeresig@gmail.com>
 Jörn Zaefferer <joern.zaefferer@gmail.com>
+Boris Moore <BorisMoore@gmail.com>
 Richard D. Worth <rdworth@gmail.com>
+Fredrik Blomqvist <fblomqvist@gmail.com>
+Andreas Blixt <me@blixt.org>
+Riku Nieminen <rikunieminen@gmail.com>
+Ed Sanders <ejsanders@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,18 +1,18 @@
 Authors ordered by first contribution
 
-InfinitiesLoop <dareed@microsoft.com>
-.NET jQuery Extensions <Swalther@Microsoft.com>
+Dave Reed <dareed@microsoft.com>
+Stephen Walther <Swalther@Microsoft.com>
 Tobie Langel <tobie.langel@gmail.com>
-jeresig <jeresig@gmail.com>
+John Resig <jeresig@gmail.com>
 Eric Bréchemier <legalbox@eric.brechemier.name>
 Nikolaus Graf <nik@deck.cc>
 Jörn Zaefferer <joern.zaefferer@gmail.com>
-BorisMoore <BorisMoore@gmail.com>
+Boris Moore <BorisMoore@gmail.com>
 Richard D. Worth <rdworth@gmail.com>
 Kyle Florence <kyle.florence@gmail.com>
 David De Sloovere <david.desloovere@hotmail.com>
 Christian Vuerings <vueringschristian@gmail.com>
-blq <fblomqvist@gmail.com>
+Fredrik Blomqvist <fblomqvist@gmail.com>
 Robert Plummer <robertleeplummerjr@gmail.com>
 Tomasz Peczek <tpeczek@gmail.com>
 Sean Cady <sean.cady@ge.com>
@@ -20,14 +20,14 @@ Oleg Gulverdashvili <ctapbiumabp@gmail.com>
 Scott González <scott.gonzalez@gmail.com>
 Nick Schonning <nschonni@gmail.com>
 Rafael Xavier de Souza <rxaviers@gmail.com>
-Blixt <me@blixt.org>
+Andreas Blixt <me@blixt.org>
 Leonardo Balter <leonardo.balter@gmail.com>
 Bao Ngo <bingo@planwise.com>
 Peter Dave Hello <hsu@peterdavehello.org>
 Raphael Amorim <rapha850@gmail.com>
 Yasuhiro Yoshida <yasuhiro.yoppu@gmail.com>
 Anne-Gaelle Colom <coloma@westminster.ac.uk>
-RikeCreates <rikunieminen@gmail.com>
+Riku Nieminen <rikunieminen@gmail.com>
 Arthur Verschaeve <contact@arthurverschaeve.be>
 Mateusz Bożyk <mateusz.bozyk@gmail.com>
 Michael Birtwell <michael.birtwell@starleaf.com>
@@ -38,7 +38,7 @@ Juan Soto <juansoto@fastmail.fm>
 Arvind Kalyan <arvchamp@gmail.com>
 Tobias Nießen <tniessen@tnie.de>
 Kevin Kirsche <Kev.Kirsche+GitHub@gmail.com>
-Ed S <ejsanders@gmail.com>
+Ed Sanders <ejsanders@gmail.com>
 John Reilly <johnny_reilly@hotmail.com>
 Isaac Durazo <isaacdurazo@gmail.com>
 Oleg Gaidarenko <markelog@gmail.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,52 @@
+Authors ordered by first contribution
+
+InfinitiesLoop <dareed@microsoft.com>
+.NET jQuery Extensions <Swalther@Microsoft.com>
+Tobie Langel <tobie.langel@gmail.com>
+jeresig <jeresig@gmail.com>
+Eric Bréchemier <legalbox@eric.brechemier.name>
+Nikolaus Graf <nik@deck.cc>
+jzaefferer <joern.zaefferer@gmail.com>
+BorisMoore <BorisMoore@gmail.com>
+Richard Worth <rdworth@gmail.com>
+Richard D. Worth <rdworth@gmail.com>
+Jörn Zaefferer <joern.zaefferer@gmail.com>
+Jörn Zaefferer <joern.zaefferer@gmail.com>
+Kyle Florence <kyle.florence@gmail.com>
+David De Sloovere <david.desloovere@hotmail.com>
+Christian Vuerings <vueringschristian@gmail.com>
+blq <fblomqvist@gmail.com>
+Robert Plummer <robertleeplummerjr@gmail.com>
+Tomasz Peczek <tpeczek@gmail.com>
+Sean Cady <sean.cady@ge.com>
+Oleg Gulverdashvili <ctapbiumabp@gmail.com>
+Scott González <scott.gonzalez@gmail.com>
+Nick Schonning <nschonni@gmail.com>
+Rafael Xavier de Souza <rxaviers@gmail.com>
+Blixt <me@blixt.org>
+Leonardo Balter <leonardo.balter@gmail.com>
+Bao Ngo <bingo@planwise.com>
+Peter Dave Hello <hsu@peterdavehello.org>
+Raphael Amorim <rapha850@gmail.com>
+Yasuhiro Yoshida <yasuhiro.yoppu@gmail.com>
+Anne-Gaelle Colom <coloma@westminster.ac.uk>
+RikeCreates <rikunieminen@gmail.com>
+Arthur Verschaeve <contact@arthurverschaeve.be>
+Mateusz Bożyk <mateusz.bozyk@gmail.com>
+Michael Birtwell <michael.birtwell@starleaf.com>
+Kris Borchers <kris.borchers@gmail.com>
+Luke Page <luke.a.page@gmail.com>
+Manraj Singh <manrajsinghgrover@gmail.com>
+Juan Soto <juansoto@fastmail.fm>
+Arvind Kalyan <arvchamp@gmail.com>
+Tobias Nießen <tniessen@tnie.de>
+Kevin Kirsche <Kev.Kirsche+GitHub@gmail.com>
+Ed S <ejsanders@gmail.com>
+John Reilly <johnny_reilly@hotmail.com>
+Isaac Durazo <isaacdurazo@gmail.com>
+Oleg Gaidarenko <markelog@gmail.com>
+Rob Garrison <wowmotty@gmail.com>
+Wes Cravens <wesley.r.cravens@gmail.com>
+Amanpreet Singh <apsdehal@gmail.com>
+Brahim Arkni <brahim.arkni@gmail.com>
+Andrew Lunny <alunny@twitter.com>

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,12 +6,9 @@ Tobie Langel <tobie.langel@gmail.com>
 jeresig <jeresig@gmail.com>
 Eric Bréchemier <legalbox@eric.brechemier.name>
 Nikolaus Graf <nik@deck.cc>
-jzaefferer <joern.zaefferer@gmail.com>
-BorisMoore <BorisMoore@gmail.com>
-Richard Worth <rdworth@gmail.com>
-Richard D. Worth <rdworth@gmail.com>
 Jörn Zaefferer <joern.zaefferer@gmail.com>
-Jörn Zaefferer <joern.zaefferer@gmail.com>
+BorisMoore <BorisMoore@gmail.com>
+Richard D. Worth <rdworth@gmail.com>
 Kyle Florence <kyle.florence@gmail.com>
 David De Sloovere <david.desloovere@hotmail.com>
 Christian Vuerings <vueringschristian@gmail.com>
@@ -50,3 +47,4 @@ Wes Cravens <wesley.r.cravens@gmail.com>
 Amanpreet Singh <apsdehal@gmail.com>
 Brahim Arkni <brahim.arkni@gmail.com>
 Andrew Lunny <alunny@twitter.com>
+Karan Sharma <karan1276@gmail.com>

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -655,7 +655,7 @@ module.exports = function( grunt ) {
 		"uglify",
 		"compare_size",
 		"commitplease",
-        "update-authors"
+		"update-authors"
 	]);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -654,7 +654,8 @@ module.exports = function( grunt ) {
 		"test:functional",
 		"uglify",
 		"compare_size",
-		"commitplease"
+		"commitplease",
+        "update-authors"
 	]);
 
 };

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-uglify": "0.6.0",
     "grunt-contrib-watch": "0.6.1",
+    "grunt-git-authors": "^3.0.0",
     "grunt-jscs": "1.8.0",
     "gzip-js": "0.3.2",
     "matchdep": "0.3.0"


### PR DESCRIPTION
Fixes #487:

I have used [this grunt plugin](https://github.com/scottgonzalez/grunt-git-authors) to create AUTHORS.txt

`update-authors` task has been registered as the last default task.

Note that i have not made any modification to `grunt-git-authors` plugin, grunt runs default `update-authors` task.
QueryUi has created a custom `update-authors` task [here](https://github.com/jquery/jquery-ui/blob/master/Gruntfile.js#L395-L422) ,on demand i can write a custom `update-authors` task as well.

i may have messed something up :sweat_smile: , let me know if something is to be corrected.

Thank You