### PR TITLE
Docs: Use official script and region names + spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ example:
 | --- | --- |
 | *en-Latn-US* | English as spoken in the Unites States in the Latin script. |
 | *en-US* | English as spoken in the Unites States (Latin script is deduced given it's the most likely script used in this place). |
-| *en* | English (United States region and Latin script are deduced given they are respectivelly the most likely region and script used in this place). |
+| *en* | English (United States region and Latin script are deduced given they are respectively the most likely region and script used in this place). |
 | *en-GB* | English as spoken in the United Kingdom (Latin script is deduced given it's the most likely script used in this place). |
 | *en-IN* | English as spoken in India (Latin script is deduced). |
 | *es* | Spanish (Spain region and Latin script are deduced). |

--- a/README.md
+++ b/README.md
@@ -401,14 +401,14 @@ example:
 | *en-IN* | English as spoken in India (Latin script is deduced). |
 | *es* | Spanish (Spain region and Latin script are deduced). |
 | *es-MX* | Spanish as spoken in Mexico (Latin script is deduced). |
-| *zh* | Chinese (China region and Hans script are deduced). |
-| *zh-TW* | Chinese as spoken in Taiwan (Hant script is deduced). |
-| *ja* | Japanese (Japan region and Japan script are deduced). |
+| *zh* | Chinese (China region and Simplified Han script are deduced). |
+| *zh-TW* | Chinese as spoken in Taiwan (Traditional Han script is deduced). |
+| *ja* | Japanese (Japan region and Japanese script are deduced). |
 | *de* | German (Germany region and Latin script are deduced). |
 | *pt* | Portuguese (Brazil region and Latin script are deduced). |
 | *pt-PT* | Portuguese as spoken in Portugal (Latin script is deduced). |
 | *fr* | French (France region and Latin script are deduced). |
-| *ru* | Russian (Russia region and Cyril script are deduced). |
+| *ru* | Russian (Russia region and Cyrillic script are deduced). |
 | *ar* | Arabic (Egypt region and Arabic script are deduced). |
 
 The likely deductibility is computed by using CLDR data, which is based on the

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ example:
 | *en-Latn-US* | English as spoken in the Unites States in the Latin script. |
 | *en-US* | English as spoken in the Unites States (Latin script is deduced given it's the most likely script used in this place). |
 | *en* | English (United States region and Latin script are deduced given they are respectivelly the most likely region and script used in this place). |
-| *en-GB* | English as spoken in the Grain Britain (Latin script is deduced given it's the most likely script used in this place). |
+| *en-GB* | English as spoken in the United Kingdom (Latin script is deduced given it's the most likely script used in this place). |
 | *en-IN* | English as spoken in India (Latin script is deduced). |
 | *es* | Spanish (Spain region and Latin script are deduced). |
 | *es-MX* | Spanish as spoken in Mexico (Latin script is deduced). |


### PR DESCRIPTION
I’m glad to see a bunch of good improvements to the docs recently! Here are a few small improvements to the _Locales_ section. I changed the script and region names to the official ones used in the `en` locale, plus corrected one misspelling. I have some ideas for further clarification and plan on contributing more to the docs in the future.

Sources:
* cldr/main/en/ldml/localeDisplayNames/scripts
* cldr/main/en/ldml/localeDisplayNames/territories