### PR TITLE
Date: Parse February correctly in leap years.

### DIFF
--- a/src/date/parse.js
+++ b/src/date/parse.js
@@ -21,7 +21,7 @@ define([
  * ref: http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Format_Patterns
  */
 return function( value, tokens, properties ) {
-	var amPm, day, daysOfYear, era, hour, hour12, timezoneOffset, valid,
+	var amPm, day, daysOfYear, month, era, hour, hour12, timezoneOffset, valid,
 		YEAR = 0,
 		MONTH = 1,
 		DAY = 2,
@@ -105,7 +105,10 @@ return function( value, tokens, properties ) {
 				if ( outOfRange( value, 1, 12 ) ) {
 					return false;
 				}
-				dateSetMonth( date, value - 1 );
+
+				// Setting the month later so that we have the correct year and can determine
+				// the correct last day of February in case of leap year.
+				month = value;
 				truncateAt.push( MONTH );
 				break;
 
@@ -245,6 +248,10 @@ return function( value, tokens, properties ) {
 
 		// 1 BC = year 0
 		date.setFullYear( date.getFullYear() * -1 + 1 );
+	}
+
+	if ( month !== undefined ) {
+		dateSetMonth( date, month - 1 );
 	}
 
 	if ( day !== undefined ) {

--- a/test/functional/date/parse-date.js
+++ b/test/functional/date/parse-date.js
@@ -20,7 +20,7 @@ define([
 	enNumbers, enTimeZoneNames, ptCaGregorian, ptNumbers, likelySubtags, numberingSystems, timeData,
 	weekData, util ) {
 
-var ar, date;
+var ar, date, FakeDate;
 
 function extraSetup() {
 	Globalize.load(
@@ -37,6 +37,36 @@ function extraSetup() {
 		weekData
 	);
 }
+
+FakeDate = (function( Date ) {
+	function FakeDate() {
+		var date;
+		if ( arguments.length === 0 ) {
+			return FakeDate.today;
+		}
+		if ( arguments.length === 1 ) {
+			date = new Date( arguments[ 0 ] );
+		} else if ( arguments.length === 2 ) {
+			date = new Date( arguments[ 0 ], arguments[ 1 ] );
+		} else if ( arguments.length === 3 ) {
+			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ] );
+		} else if ( arguments.length === 4 ) {
+			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ], arguments[ 3 ] );
+		} else if ( arguments.length === 5 ) {
+			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ], arguments[ 3 ], arguments[ 4 ] );
+		} else if ( arguments.length === 6 ) {
+			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ], arguments[ 3 ], arguments[ 4 ], arguments[ 5 ] );
+		} else if ( arguments.length === 7 ) {
+			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ], arguments[ 3 ], arguments[ 4 ], arguments[ 5 ], arguments[ 6 ] );
+		}
+
+		/* jshint proto:true */
+		date.__proto__ = FakeDate.prototype;
+		return date;
+	}
+	FakeDate.prototype = FakeDate.today = new Date();
+	return FakeDate;
+})( Date );
 
 QUnit.module( ".parseDate( value, options )", {
 	setup: function() {
@@ -140,7 +170,15 @@ QUnit.test( "should parse date presets", function( assert ) {
 });
 
 QUnit.test( "should parse date correctly in leap year", function( assert ) {
+	var OrigDate;
+
 	extraSetup();
+
+	/* globals Date:true */
+	// Use a leap year and a day of month greater than 28
+	OrigDate = Date;
+	Date = FakeDate;
+	FakeDate.today = new Date( 2016, 0, 29 );
 
 	date = new Date( 2015, 1, 15 );
 	date = startOf( date, "day" );
@@ -148,6 +186,8 @@ QUnit.test( "should parse date correctly in leap year", function( assert ) {
 	assertParseDate( assert, "February 15, 2015", { date: "long" }, date );
 	assertParseDate( assert, "Feb 15, 2015", { date: "medium" }, date );
 	assertParseDate( assert, "2/15/15", { date: "short" }, date );
+
+	Date = OrigDate;
 });
 
 QUnit.test( "should parse datetime presets", function( assert ) {

--- a/test/functional/date/parse-date.js
+++ b/test/functional/date/parse-date.js
@@ -139,6 +139,17 @@ QUnit.test( "should parse date presets", function( assert ) {
 	assertParseDate( assert, "9/15/10", { date: "short" }, date );
 });
 
+QUnit.test( "should parse date correctly in leap year", function( assert ) {
+	extraSetup();
+
+	date = new Date( 2015, 1, 15 );
+	date = startOf( date, "day" );
+	assertParseDate( assert, "Wednesday, February 15, 2015", { date: "full" }, date );
+	assertParseDate( assert, "February 15, 2015", { date: "long" }, date );
+	assertParseDate( assert, "Feb 15, 2015", { date: "medium" }, date );
+	assertParseDate( assert, "2/15/15", { date: "short" }, date );
+});
+
 QUnit.test( "should parse datetime presets", function( assert ) {
 	extraSetup();
 

--- a/test/functional/date/parse-date.js
+++ b/test/functional/date/parse-date.js
@@ -20,7 +20,7 @@ define([
 	enNumbers, enTimeZoneNames, ptCaGregorian, ptNumbers, likelySubtags, numberingSystems, timeData,
 	weekData, util ) {
 
-var ar, date, FakeDate;
+var ar, date;
 
 function extraSetup() {
 	Globalize.load(
@@ -37,36 +37,6 @@ function extraSetup() {
 		weekData
 	);
 }
-
-FakeDate = (function( Date ) {
-	function FakeDate() {
-		var date;
-		if ( arguments.length === 0 ) {
-			return FakeDate.today;
-		}
-		if ( arguments.length === 1 ) {
-			date = new Date( arguments[ 0 ] );
-		} else if ( arguments.length === 2 ) {
-			date = new Date( arguments[ 0 ], arguments[ 1 ] );
-		} else if ( arguments.length === 3 ) {
-			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ] );
-		} else if ( arguments.length === 4 ) {
-			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ], arguments[ 3 ] );
-		} else if ( arguments.length === 5 ) {
-			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ], arguments[ 3 ], arguments[ 4 ] );
-		} else if ( arguments.length === 6 ) {
-			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ], arguments[ 3 ], arguments[ 4 ], arguments[ 5 ] );
-		} else if ( arguments.length === 7 ) {
-			date = new Date( arguments[ 0 ], arguments[ 1 ], arguments[ 2 ], arguments[ 3 ], arguments[ 4 ], arguments[ 5 ], arguments[ 6 ] );
-		}
-
-		/* jshint proto:true */
-		date.__proto__ = FakeDate.prototype;
-		return date;
-	}
-	FakeDate.prototype = FakeDate.today = new Date();
-	return FakeDate;
-})( Date );
 
 QUnit.module( ".parseDate( value, options )", {
 	setup: function() {
@@ -167,27 +137,6 @@ QUnit.test( "should parse date presets", function( assert ) {
 	assertParseDate( assert, "September 15, 2010", { date: "long" }, date );
 	assertParseDate( assert, "Sep 15, 2010", { date: "medium" }, date );
 	assertParseDate( assert, "9/15/10", { date: "short" }, date );
-});
-
-QUnit.test( "should parse date correctly in leap year", function( assert ) {
-	var OrigDate;
-
-	extraSetup();
-
-	/* globals Date:true */
-	// Use a leap year and a day of month greater than 28
-	OrigDate = Date;
-	Date = FakeDate;
-	FakeDate.today = new Date( 2016, 0, 29 );
-
-	date = new Date( 2015, 1, 15 );
-	date = startOf( date, "day" );
-	assertParseDate( assert, "Wednesday, February 15, 2015", { date: "full" }, date );
-	assertParseDate( assert, "February 15, 2015", { date: "long" }, date );
-	assertParseDate( assert, "Feb 15, 2015", { date: "medium" }, date );
-	assertParseDate( assert, "2/15/15", { date: "short" }, date );
-
-	Date = OrigDate;
 });
 
 QUnit.test( "should parse datetime presets", function( assert ) {

--- a/test/unit/date/parse.js
+++ b/test/unit/date/parse.js
@@ -188,6 +188,25 @@ QUnit.test( "should parse month (MMMMM|LLLLL)", function( assert ) {
 	assertParse( assert, "J", "LLLLL", cldr, date1 );
 });
 
+QUnit.test( "should parse February correctly in leap year", function( assert ) {
+	var OrigDate;
+
+	/* globals Date:true */
+	// Use a leap year and a day of month greater than 28
+	OrigDate = Date;
+	Date = FakeDate;
+	FakeDate.today = new Date( 2016, 0, 29 );
+
+	date1 = new Date();
+	date1.setMonth( 1 );
+	date1 = startOf( date1, "month" );
+	date1.setYear( 2015 );
+	assertParse( assert, "2/2015", "M/y", cldr, date1 );
+	assertParse( assert, "2/2015", "L/y", cldr, date1 );
+
+	Date = OrigDate;
+});
+
 /**
  *  Day
  */


### PR DESCRIPTION
When setting the month, the date parser may set the day to the last day
of the month.  If the year has not yet been set, this will be the last
day of the month in the current year.  So for example, in 2016 "2/1/15"
would be month-parsed to "Feb 29, 2016", then year-parsed to
"Mar 1, 2015".  The fix is set the month after the year has been set.

Also added a test for this case.

Fixes #585.