### PR TITLE
Fix broken link in the date-formatter doc

### DIFF
--- a/doc/api/date/date-formatter.md
+++ b/doc/api/date/date-formatter.md
@@ -21,8 +21,7 @@ A JSON object including one of the following.
 > list `full`, `long`, `medium`, or `short` represented by date, time, or
 > datetime.  Instead, they are an open-ended list of patterns containing
 > only date field information, and in a canonical order. For a complete list of 
-> skeleton patterns [check the unicode CLDR documentation](http://www.unicode.o
-> rg/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table).
+> skeleton patterns [check the unicode CLDR documentation](http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table).
 > 
 > For example:
 >


### PR DESCRIPTION
The current link for the CLDR document of the skeleton patterns is actually broken because of a new line at the end of the url in the markdown (Firefox / Chrome / IE11). The url is unicode.o%0arg instead of unicode.org due to the newline being encoded.

https://github.com/jquery/globalize/blob/master/doc/api/date/date-formatter.md#parameters