### PR TITLE
Globalize:Provide Bidi structured text support to MessageFormat

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,8 @@
   },
   "devDependencies": {
     "es5-shim": "3.4.0",
-    "make-plural": "eemeli/make-plural.js#3.0.0",
-    "messageformat": "SlexAxton/messageformat.js#v0.3.0-1",
+    "make-plural": "eemeli/make-plural.js#^3.0.0-rc4",
+    "messageformat": "SlexAxton/messageformat.js#v0.3.0",
     "qunit": "1.18.0",
     "requirejs": "2.1.20",
     "requirejs-plugins": "1.0.2",

--- a/doc/api/message/message-formatter.md
+++ b/doc/api/message/message-formatter.md
@@ -1,4 +1,4 @@
-## .messageFormatter( path, isStructuredBidiText ) ➡ function([ variables ])
+## .messageFormatter( path, options ) ➡ function([ variables ])
 
 Return a function that formats a message (using ICU message format pattern)
 given its path and a set of variables into a user-readable string. It supports
@@ -14,9 +14,12 @@ messages data.
 String or Array containing the path of the message content, eg.
 `"greetings/bye"`, or `[ "greetings", "bye" ]`.
 
-**isStructuredBidiText**
+**options** (optional)
 
-Boolean value indicating that Bidi structuring should be imposed on formatted message.
+Options should be an Objects, where each property can be referenced by name.
+The possible property having name recognizable by messageFormatter is "setBiDiSupport".
+It should have Boolean value indicating whether Bidi structuring is to be imposed on formatted 
+message (like {"setBiDiSupport": true}).
 Special Unicode Bidi marks are inserted depending on locale in order to preserve the text 
 flow of structured message which corresponds give local (from right-to-left for Bidi scripts 
 like Arabic, Hebrew or Pharsi and left-to-right otherwise.
@@ -225,7 +228,7 @@ likeFormatter( 3 );
 	Globalize.loadMessages({
 		ar: { breadcrumb: "{0} >> {1} >> {2}" }		
 	}); 
-bidiFormatter = Globalize( "ar" ).messageFormatter( "breadcrumb", true );
+bidiFormatter = Globalize( "ar" ).messageFormatter( "breadcrumb", {"setBiDiSupport": true} );
 
 bidiFormatter( "First", "Second", "Third" );
 // > "Third << Second << First"

--- a/doc/api/message/message-formatter.md
+++ b/doc/api/message/message-formatter.md
@@ -1,4 +1,4 @@
-## .messageFormatter( path ) ➡ function([ variables ])
+## .messageFormatter( path, isStructuredBidiText ) ➡ function([ variables ])
 
 Return a function that formats a message (using ICU message format pattern)
 given its path and a set of variables into a user-readable string. It supports
@@ -13,6 +13,15 @@ messages data.
 
 String or Array containing the path of the message content, eg.
 `"greetings/bye"`, or `[ "greetings", "bye" ]`.
+
+**isStructuredBidiText**
+
+Boolean value indicating that Bidi structuring should be imposed on formatted message.
+Special Unicode Bidi marks are inserted depending on locale in order to preserve the text 
+flow of structured message which corresponds give local (from right-to-left for Bidi scripts 
+like Arabic, Hebrew or Pharsi and left-to-right otherwise.
+For more info on Bidi structured text see: 
+http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text
 
 **variables** (optional)
 
@@ -212,6 +221,15 @@ likeFormatter( 2 );
 likeFormatter( 3 );
 // > "You and 2 others liked this"
 ```
+#### Bidi structured meessage
+	Globalize.loadMessages({
+		ar: { breadcrumb: "{0} >> {1} >> {2}" }		
+	}); 
+bidiFormatter = Globalize( "ar" ).messageFormatter( "breadcrumb", true );
+
+bidiFormatter( "First", "Second", "Third" );
+// > "Third << Second << First"
+
 
 Read on [SlexAxton/messageFormatter.js][] for more information on regard of ICU
 MessageFormat.

--- a/src/message.js
+++ b/src/message.js
@@ -56,10 +56,12 @@ Globalize.loadMessages = function( json ) {
  *
  * @path [String or Array]
  *
+ * @options [object]
+ *
  * Format a message given its path.
  */
 Globalize.messageFormatter =
-Globalize.prototype.messageFormatter = function( path, isStructuredBidiText ) {
+Globalize.prototype.messageFormatter = function( path, options ) {
 	var cldr, messageFormat, formatter, message, pluralGenerator, returnFn,
 		args = slice.call( arguments, 0 );
 
@@ -88,7 +90,7 @@ Globalize.prototype.messageFormatter = function( path, isStructuredBidiText ) {
 		createErrorPluralModulePresence;
 
 	messageFormat = new MessageFormat( cldr.locale, pluralGenerator );
-	if ( typeof isStructuredBidiText === "boolean" && isStructuredBidiText ) {
+	if ( options && ( options.setBiDiSupport === true ) ) {
 		messageFormat.setBiDiSupport( true );
 	}
 	formatter = messageFormat.compile( message );
@@ -112,7 +114,7 @@ Globalize.prototype.messageFormatter = function( path, isStructuredBidiText ) {
  */
 Globalize.formatMessage =
 Globalize.prototype.formatMessage = function( path /* , variables */ ) {
-	return ( arguments[ 1 ] && typeof arguments[ 1 ] === "boolean" ) ?
+	return ( arguments[ 1 ] && arguments[ 1 ].setBiDiSupport === true ) ?
 		this.messageFormatter( path, arguments[ 1 ] ).apply( {}, slice.call( arguments, 2 ) ) :
 		this.messageFormatter( path ).apply( {}, slice.call( arguments, 1 ) );
 };

--- a/src/message.js
+++ b/src/message.js
@@ -59,8 +59,8 @@ Globalize.loadMessages = function( json ) {
  * Format a message given its path.
  */
 Globalize.messageFormatter =
-Globalize.prototype.messageFormatter = function( path ) {
-	var cldr, formatter, message, pluralGenerator, returnFn,
+Globalize.prototype.messageFormatter = function( path, isStructuredBidiText ) {
+	var cldr, messageFormat, formatter, message, pluralGenerator, returnFn,
 		args = slice.call( arguments, 0 );
 
 	validateParameterPresence( path, "path" );
@@ -87,7 +87,11 @@ Globalize.prototype.messageFormatter = function( path ) {
 		this.pluralGenerator() :
 		createErrorPluralModulePresence;
 
-	formatter = new MessageFormat( cldr.locale, pluralGenerator ).compile( message );
+	messageFormat = new MessageFormat( cldr.locale, pluralGenerator );
+	if ( typeof isStructuredBidiText === "boolean" && isStructuredBidiText ) {
+		messageFormat.setBiDiSupport( true );
+	}
+	formatter = messageFormat.compile( message );
 
 	returnFn = messageFormatterFn( formatter );
 
@@ -108,7 +112,9 @@ Globalize.prototype.messageFormatter = function( path ) {
  */
 Globalize.formatMessage =
 Globalize.prototype.formatMessage = function( path /* , variables */ ) {
-	return this.messageFormatter( path ).apply( {}, slice.call( arguments, 1 ) );
+	return ( arguments[ 1 ] && typeof arguments[ 1 ] === "boolean" ) ?
+		this.messageFormatter( path, arguments[ 1 ] ).apply( {}, slice.call( arguments, 2 ) ) :
+		this.messageFormatter( path ).apply( {}, slice.call( arguments, 1 ) );
 };
 
 return Globalize;

--- a/test/functional/message/format-message.js
+++ b/test/functional/message/format-message.js
@@ -17,6 +17,9 @@ QUnit.module( ".formatMessage( path [, variables] )", {
 				greetings: {
 					hello: "Hello, {name}"
 				}
+			},
+			he: {
+				breadcrumb: "{0} >> {1} >> {2}",
 			}
 		});
 	},
@@ -45,6 +48,18 @@ QUnit.test( "should format a message", function( assert ) {
 	assert.equal( Globalize( "en" ).formatMessage( "greetings/hello", {
 		name: "Beethoven"
 	}), "Hello, Beethoven" );
+});
+
+QUnit.test( "should format a message", function( assert ) {
+	assert.equal( Globalize( "en" ).formatMessage( "greetings/hello", {
+		name: "Beethoven"
+	}), "Hello, Beethoven" );
+});
+
+QUnit.test( "should support Bidi structured text", function( assert ) {
+	assert.equal( Globalize( "he" ).formatMessage( "breadcrumb", true,
+	[ "Mozart", "Bethoven", "Dvorzak" ]
+	), "\u200FMozart\u200F >> \u200FBethoven\u200F >> \u200FDvorzak\u200F" );
 });
 
 });

--- a/test/functional/message/format-message.js
+++ b/test/functional/message/format-message.js
@@ -1,4 +1,4 @@
-define([
+﻿define([
 	"globalize",
 	"json!cldr-data/supplemental/likelySubtags.json",
 	"json!cldr-data/supplemental/plurals.json",
@@ -57,7 +57,7 @@ QUnit.test( "should format a message", function( assert ) {
 });
 
 QUnit.test( "should support Bidi structured text", function( assert ) {
-	assert.equal( Globalize( "he" ).formatMessage( "breadcrumb", true,
+	assert.equal( Globalize( "he" ).formatMessage( "breadcrumb", {"setBiDiSupport": true},
 	[ "Mozart", "Bethoven", "Dvorzak" ]
 	), "\u200FMozart\u200F >> \u200FBethoven\u200F >> \u200FDvorzak\u200F" );
 });

--- a/test/functional/message/message-formatter.js
+++ b/test/functional/message/message-formatter.js
@@ -64,6 +64,9 @@ QUnit.module( ".messageFormatter( path )", {
 			},
 			"en-GB": {},
 			fr: {},
+			he: {
+				helloArray: "\u05e9\u05dc\u05d5\u05dd, {0} & {1}"
+			},
 			pt: {
 				amen: "Amém"
 			},
@@ -173,6 +176,13 @@ QUnit.test( "should support ICU message format", function( assert ) {
 	}), "You and Beethoven liked this" );
 
 	assert.equal( like({ count: 3 }), "You and 2 others liked this" );
+});
+
+QUnit.test( "should support Bidi structured text", function( assert ) {
+	assert.equal(
+		Globalize( "he" ).messageFormatter( "helloArray", true )( "Beethoven", "Mozart" ),
+		"\u05e9\u05dc\u05d5\u05dd, \u200FBeethoven\u200F & \u200FMozart\u200F"
+	);
 });
 
 // Reference #473

--- a/test/functional/message/message-formatter.js
+++ b/test/functional/message/message-formatter.js
@@ -65,7 +65,7 @@ QUnit.module( ".messageFormatter( path )", {
 			"en-GB": {},
 			fr: {},
 			he: {
-				helloArray: "\u05e9\u05dc\u05d5\u05dd, {0} & {1}"
+				helloArray: "Hello, {0} & {1}"
 			},
 			pt: {
 				amen: "Amém"
@@ -180,8 +180,8 @@ QUnit.test( "should support ICU message format", function( assert ) {
 
 QUnit.test( "should support Bidi structured text", function( assert ) {
 	assert.equal(
-		Globalize( "he" ).messageFormatter( "helloArray", true )( "Beethoven", "Mozart" ),
-		"\u05e9\u05dc\u05d5\u05dd, \u200FBeethoven\u200F & \u200FMozart\u200F"
+		Globalize( "he" ).messageFormatter( "helloArray", {"setBiDiSupport": true} )( "Beethoven", "Mozart" ),
+		"Hello, \u200FBeethoven\u200F & \u200FMozart\u200F"
 	);
 });
 


### PR DESCRIPTION
As per discussion in #539 (comment)
this PR is based on corresponding feature been recently introduced in SlexAxton/messageFormatter.js
(see SlexAxton/messageformat.js#129)
It provides an ability to enforce Bidi structured text in message being formatted by using Unicode Bidi control characters. The upgrading qualities are:

    Prevents intermingling of text contained in placeholders with the rest of message text.
    Maintains the integrity of Bidi text flowing according to directionality of language script. For reference to Bidi structured text see: http://cldr.unicode.org/development/development-process/design-proposals/bidi-handling-of-structured-text

