### PR TITLE
Module names

### DIFF
--- a/src/number.js
+++ b/src/number.js
@@ -18,8 +18,8 @@ define([
 	"./number/symbol",
 	"./util/string/pad",
 
-	"cldr/event",
-	"cldr/supplemental"
+	"cldr-event",
+	"cldr-supplemental"
 ], function( Globalize, createErrorUnsupportedFeature, runtimeBind, validateCldr,
 	validateDefaultLocale, validateParameterPresence, validateParameterRange,
 	validateParameterTypeNumber, validateParameterTypePlainObject, validateParameterTypeString,


### PR DESCRIPTION
Module names should not contain path delimiter: "cldr/event", "cldr-event". This makes a lot of trouble with require.